### PR TITLE
docs/29/update needs assessment `readme.md` with new sections

### DIFF
--- a/needs-assessment/README.md
+++ b/needs-assessment/README.md
@@ -1,5 +1,16 @@
-# Needs Assessment Information
+# Needs Assessment Information - Historic Data
 
 The current needs assessment information utilized for this documentation was obtained from the historic needs data. It is filtered through scripts that process the data to ensure specific requirements are met prior to uploading the information to the Strapi collections. The data can then be accessed through Strapi API endpoints for frontend integration. (See the diagram below for an overview of this process.)
 
 ![Data Processing Pipeline](../images/data-transfer.png)
+
+## Table of Contents
+
+- [Needs Assessment Information - Historical Data](#needs-assessment-information---historic-data)
+- Data Processing Scripts
+- Strapi Collections
+- [Troubleshooting](#troubleshooting)
+
+## Troubleshooting
+
+Some points to note if experiencing issues when getting the repo setup in a local dev environment or possible GitHub codespace requirements.

--- a/needs-assessment/README.md
+++ b/needs-assessment/README.md
@@ -13,4 +13,4 @@ The current needs assessment information utilized for this documentation was obt
 
 ## Troubleshooting
 
-Some points to note if experiencing issues when getting the repo setup in a local dev environment or possible GitHub codespace requirements.
+Some points to note if experiencing issues when getting the repo running in a local dev environment or possible GitHub codespace requirements.


### PR DESCRIPTION
This PR renames the header for the Needs Assessment `readme.md` to include a reference to the historic data and adds 2 sections to the file:

- Table of Contents
- Troubleshooting

It closes [Issue#29](https://github.com/distributeaid/docs/issues/29).